### PR TITLE
Signing without testkey and debug key

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,12 @@ jobs:
       - name: Clone repository
         run: git clone --depth=1 -b ${{ env.ANDROIDV }} https://gitlab.com/MindTheGapps/vendor_gapps.git/
 
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '8'
+
       - name: Build
         working-directory: vendor_gapps
         continue-on-error: true
@@ -57,12 +63,13 @@ jobs:
             sed -i -e '/overlay/d' build/gapps.sh
             sed -i -e '/RROs/d' build/gapps.sh
             echo "Compiling RROs"
+            keytool -genkey -v -keystore debug.keystore -alias androiddebugkey -keyalg RSA -validity 10000 -dname "CN=Android Debug,O=Android,C=US" -storepass android
             find overlay -maxdepth 1 -mindepth 1 -type d -print0 | while IFS= read -r -d '' dir
             do
                 echo "Building ${dir/overlay\//}"
-                aapt package -M "$dir"/AndroidManifest.xml -S "$dir"/res/ -I /usr/local/lib/android/sdk/platforms/android-${{ env.ANDROID_API }}/android.jar -F "${dir/overlay\//}"-unaligned-unsigned.apk
-                zipalign -v 4 "${dir/overlay\//}"-unaligned-unsigned.apk "${dir/overlay\//}"-unsigned.apk
-                java -jar build/sign/signapk.jar build/sign/testkey.x509.pem build/sign/testkey.pk8 "${dir/overlay\//}"-unsigned.apk "${dir/overlay\//}".apk
+                aapt package -M "$dir"/AndroidManifest.xml -S "$dir"/res/ -I /usr/local/lib/android/sdk/platforms/android-${{ env.ANDROID_API }}/android.jar -F "${dir/overlay\//}"-.apk
+                jarsigner -keystore debug.keystore "${dir/overlay\//}".apk androiddebugkey -storepass android
+                zipalign -f -v 4 "${dir/overlay\//}".apk
                 mv -v "${dir/overlay\//}".apk common/proprietary/product/overlay
             done
           fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,13 +81,20 @@ jobs:
           echo "date=$(date -u +%Y%m%d)" >> $GITHUB_ENV
           ./build/gapps.sh ${{ matrix.arch }}
           sed -i -e 's@/home/runner/work/MindTheGappsBuilder/MindTheGappsBuilder/vendor_gapps/out/@@' out/MindTheGapps-${{ matrix.androidv }}-${{ matrix.arch }}-$(date -u +%Y%m%d).zip.md5sum
+          mkdir out/${{ matrix.arch }}
+          mkdir out/${{ matrix.arch }}/${{ env.date }}
+          mkdir out/${{ matrix.arch }}/${{ env.date }}/keys
+          mv ../cert-${{ matrix.androidv }}-${{ matrix.arch }}.* out/${{ matrix.arch }}/${{ env.date }}/keys
 
       - name: Upload
         if: github.event.inputs.release != 'true'
         uses: actions/upload-artifact@v3
         with:
           name: Built_MindTheGapps-${{ matrix.androidv }}-${{ matrix.arch }}-${{ env.date }}
-          path: vendor_gapps/out/*
+          path: |
+            vendor_gapps/out/*.zip
+            vendor_gapps/out/*.zip.md5
+            vendor_gapps/out/keys/
           if-no-files-found: warn
 
       - name: Setup SSH
@@ -104,11 +111,7 @@ jobs:
         if: github.event.inputs.release == 'true'
         working-directory: vendor_gapps/out
         run: |
-          mkdir ${{ matrix.arch }}
-          mkdir ${{ matrix.arch }}/${{ env.date }}
-          mkdir ${{ matrix.arch }}/${{ env.date }}/keys
           mv *.* ${{ matrix.arch }}/${{ env.date }}
-          mv ../../cert-${{ matrix.androidv }}-${{ matrix.arch }}.* ${{ matrix.arch }}/${{ env.date }}/keys
           rsync -avP -e ssh ${{ matrix.arch }} ${{ vars.SF_USER }}@frs.sourceforge.net:/home/frs/project/wsa-mtg/
 
       - name: Release
@@ -118,4 +121,7 @@ jobs:
           tag_name: ${{ env.date }}
           draft: false
           prerelease: false
-          files: vendor_gapps/out/*
+          files: |
+            vendor_gapps/out/*.zip
+            vendor_gapps/out/*.zip.md5sum
+            vendor_gapps/out/keys/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,10 +84,10 @@ jobs:
           sed -i -e 's@/home/runner/work/MindTheGappsBuilder/MindTheGappsBuilder/vendor_gapps/out/@@' out/MindTheGapps-${{ matrix.androidv }}-${{ matrix.arch }}-$(date -u +%Y%m%d).zip.md5sum
           mkdir -p out/${{ matrix.arch }}
           mkdir -p out/${{ matrix.arch }}/$cdate
-          mv -v out/*.* out/${{ matrix.arch }}/$cdate
+          mv out/*.* out/${{ matrix.arch }}/$cdate
           if [ -d overlay ]; then
             mkdir -p out/${{ matrix.arch }}/$cdate/keys
-            mv -v cert-${{ matrix.androidv }}-${{ matrix.arch }}.* out/${{ matrix.arch }}/$cdate/keys
+            mv cert-*.* out/${{ matrix.arch }}/$cdate/keys
           fi
 
       - name: Upload

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,8 +66,7 @@ jobs:
             sed -i -e '/overlay/d' build/gapps.sh
             sed -i -e '/RROs/d' build/gapps.sh
             echo "Compiling RROs"
-            find overlay -maxdepth 1 -mindepth 1 -type d -print0 | while IFS= read -r -d '' dir
-            do
+            find overlay -maxdepth 1 -mindepth 1 -type d -print0 | while IFS= read -r -d '' dir; do
                 echo "Building ${dir/overlay\//}"
                 aapt package -M "$dir"/AndroidManifest.xml -S "$dir"/res/ -I /usr/local/lib/android/sdk/platforms/android-${{ env.ANDROID_API }}/android.jar -F "${dir/overlay\//}".apk.u
                 zipalign -v 4 "${dir/overlay\//}".apk.u "${dir/overlay\//}".apk
@@ -76,15 +75,16 @@ jobs:
             done
             mv cert.pem cert-${{ matrix.androidv }}-${{ matrix.arch }}.pem
             mv cert.pk8 cert-${{ matrix.androidv }}-${{ matrix.arch }}.pk8
+            rm key.pem
           fi
           sed -i -e 's/_%H%M%S//' build/gapps.sh
           echo "date=$(date -u +%Y%m%d)" >> $GITHUB_ENV
           ./build/gapps.sh ${{ matrix.arch }}
           sed -i -e 's@/home/runner/work/MindTheGappsBuilder/MindTheGappsBuilder/vendor_gapps/out/@@' out/MindTheGapps-${{ matrix.androidv }}-${{ matrix.arch }}-$(date -u +%Y%m%d).zip.md5sum
-          mkdir out/${{ matrix.arch }}
-          mkdir out/${{ matrix.arch }}/${{ env.date }}
-          mkdir out/${{ matrix.arch }}/${{ env.date }}/keys
+          mkdir -p out/${{ matrix.arch }}/${{ env.date }}
+          mkdir -p out/${{ matrix.arch }}/${{ env.date }}/keys
           mv ../cert-${{ matrix.androidv }}-${{ matrix.arch }}.* out/${{ matrix.arch }}/${{ env.date }}/keys
+          mv out/*.* out/${{ matrix.arch }}/${{ env.date }}
 
       - name: Upload
         if: github.event.inputs.release != 'true'
@@ -92,9 +92,8 @@ jobs:
         with:
           name: Built_MindTheGapps-${{ matrix.androidv }}-${{ matrix.arch }}-${{ env.date }}
           path: |
-            vendor_gapps/out/*.zip
-            vendor_gapps/out/*.zip.md5
-            vendor_gapps/out/keys/
+            vendor_gapps/out/${{ matrix.arch }}/${{ env.date }/*.*
+            vendor_gapps/out/${{ matrix.arch }}/${{ env.date }}/keys/
           if-no-files-found: warn
 
       - name: Setup SSH
@@ -110,9 +109,7 @@ jobs:
         continue-on-error: true
         if: github.event.inputs.release == 'true'
         working-directory: vendor_gapps/out
-        run: |
-          mv *.* ${{ matrix.arch }}/${{ env.date }}
-          rsync -avP -e ssh ${{ matrix.arch }} ${{ vars.SF_USER }}@frs.sourceforge.net:/home/frs/project/wsa-mtg/
+        run: rsync -avP -e ssh ${{ matrix.arch }} ${{ vars.SF_USER }}@frs.sourceforge.net:/home/frs/project/wsa-mtg/
 
       - name: Release
         uses: softprops/action-gh-release@v1
@@ -122,6 +119,5 @@ jobs:
           draft: false
           prerelease: false
           files: |
-            vendor_gapps/out/*.zip
-            vendor_gapps/out/*.zip.md5sum
-            vendor_gapps/out/keys/*
+            vendor_gapps/out/${{ matrix.arch }}/${{ env.date }/*.*
+            vendor_gapps/out/${{ matrix.arch }}/${{ env.date }/keys/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,12 +62,12 @@ jobs:
             mkdir common/proprietary/product/overlay
             sed -i -e '/overlay/d' build/gapps.sh
             sed -i -e '/RROs/d' build/gapps.sh
-            echo "Compiling RROs"
             keytool -genkey -v -keystore debug.keystore -alias androiddebugkey -keyalg RSA -validity 10000 -dname "CN=Android Debug,O=Android,C=US" -storepass android
+            echo "Compiling RROs"
             find overlay -maxdepth 1 -mindepth 1 -type d -print0 | while IFS= read -r -d '' dir
             do
                 echo "Building ${dir/overlay\//}"
-                aapt package -M "$dir"/AndroidManifest.xml -S "$dir"/res/ -I /usr/local/lib/android/sdk/platforms/android-${{ env.ANDROID_API }}/android.jar -F "${dir/overlay\//}"-.apk
+                aapt package -M "$dir"/AndroidManifest.xml -S "$dir"/res/ -I /usr/local/lib/android/sdk/platforms/android-${{ env.ANDROID_API }}/android.jar -F "${dir/overlay\//}".apk
                 jarsigner -keystore debug.keystore "${dir/overlay\//}".apk androiddebugkey -storepass android
                 zipalign -f -v 4 "${dir/overlay\//}".apk
                 mv -v "${dir/overlay\//}".apk common/proprietary/product/overlay

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,7 +83,7 @@ jobs:
           sed -i -e 's@/home/runner/work/MindTheGappsBuilder/MindTheGappsBuilder/vendor_gapps/out/@@' out/MindTheGapps-${{ matrix.androidv }}-${{ matrix.arch }}-$(date -u +%Y%m%d).zip.md5sum
           mkdir -p out/${{ matrix.arch }}/${{ env.date }}
           mkdir -p out/${{ matrix.arch }}/${{ env.date }}/keys
-          mv ../cert-${{ matrix.androidv }}-${{ matrix.arch }}.* out/${{ matrix.arch }}/${{ env.date }}/keys
+          mv cert-${{ matrix.androidv }}-${{ matrix.arch }}.* out/${{ matrix.arch }}/${{ env.date }}/keys
           mv out/*.* out/${{ matrix.arch }}/${{ env.date }}
 
       - name: Upload

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,9 +67,9 @@ jobs:
             find overlay -maxdepth 1 -mindepth 1 -type d -print0 | while IFS= read -r -d '' dir
             do
                 echo "Building ${dir/overlay\//}"
-                aapt package -M "$dir"/AndroidManifest.xml -S "$dir"/res/ -I /usr/local/lib/android/sdk/platforms/android-${{ env.ANDROID_API }}/android.jar -F "${dir/overlay\//}".apk
-                jarsigner -keystore debug.keystore "${dir/overlay\//}".apk androiddebugkey -storepass android
-                zipalign -f -v 4 "${dir/overlay\//}".apk
+                aapt package -M "$dir"/AndroidManifest.xml -S "$dir"/res/ -I /usr/local/lib/android/sdk/platforms/android-${{ env.ANDROID_API }}/android.jar -F "${dir/overlay\//}".apk.u
+                jarsigner -keystore debug.keystore "${dir/overlay\//}".apk.u androiddebugkey -storepass android
+                zipalign -v 4 "${dir/overlay\//}".apk.u "${dir/overlay\//}".apk
                 mv -v "${dir/overlay\//}".apk common/proprietary/product/overlay
             done
           fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,12 @@ jobs:
             matrix.androidv = ["9.0.0", "10.0.0", "11.0.0", "12.1.0", "13.0.0"]
             matrix.arch = ["arm", "arm64", "x86", "x86_64"]
             core.setOutput("matrix", JSON.stringify(matrix));
+            
+      - name: Create signing keys
+        run: |
+          openssl genrsa -f4 2048 > key.pem
+          openssl pkcs8 -in key.pem -topk8 -outform DER -out cert.pk8 -nocrypt
+          openssl req -new -x509 -sha256 -key key.pem -out cert.pem -days 10000 -subj '/C=US/ST=California/L=Mountain View/O=Android/OU=Android/CN=Android/emailAddress=android@android.com'
 
   build:
     name: Build ${{ matrix.androidv }}-${{ matrix.arch }}
@@ -58,18 +64,17 @@ jobs:
           if [[ ! -d overlay && ${{ matrix.arch }} == x86_64 ]]; then exit 64; fi
           if [ -d overlay ]; then
             sudo apt-get update
-            sudo apt-get install -y aapt zipalign
+            sudo apt-get install -y aapt zipalign apksigner
             mkdir common/proprietary/product/overlay
             sed -i -e '/overlay/d' build/gapps.sh
             sed -i -e '/RROs/d' build/gapps.sh
-            keytool -genkey -v -keystore debug.keystore -alias androiddebugkey -keyalg RSA -validity 10000 -dname "CN=Android Debug,O=Android,C=US" -storepass android
             echo "Compiling RROs"
             find overlay -maxdepth 1 -mindepth 1 -type d -print0 | while IFS= read -r -d '' dir
             do
                 echo "Building ${dir/overlay\//}"
                 aapt package -M "$dir"/AndroidManifest.xml -S "$dir"/res/ -I /usr/local/lib/android/sdk/platforms/android-${{ env.ANDROID_API }}/android.jar -F "${dir/overlay\//}".apk.u
-                jarsigner -keystore debug.keystore "${dir/overlay\//}".apk.u androiddebugkey -storepass android
                 zipalign -v 4 "${dir/overlay\//}".apk.u "${dir/overlay\//}".apk
+                apksigner sign --key cert.pk8 --cert cert.pem "${dir/overlay\//}".apk
                 mv -v "${dir/overlay\//}".apk common/proprietary/product/overlay
             done
           fi
@@ -103,6 +108,7 @@ jobs:
           mkdir ${{ matrix.arch }}
           mkdir ${{ matrix.arch }}/${{ env.date }}
           mv *.* ${{ matrix.arch }}/${{ env.date }}
+          mv ../cert.* ${{ matrix.arch }}/${{ env.date }}
           rsync -avP -e ssh ${{ matrix.arch }} ${{ vars.SF_USER }}@frs.sourceforge.net:/home/frs/project/wsa-mtg/
 
       - name: Release
@@ -112,4 +118,6 @@ jobs:
           tag_name: ${{ env.date }}
           draft: false
           prerelease: false
-          files: vendor_gapps/out/*
+          files: |
+            vendor_gapps/out/*
+            cert.*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
             matrix.androidv = ["9.0.0", "10.0.0", "11.0.0", "12.1.0", "13.0.0"]
             matrix.arch = ["arm", "arm64", "x86", "x86_64"]
             core.setOutput("matrix", JSON.stringify(matrix));
-            
+
   build:
     name: Build ${{ matrix.androidv }}-${{ matrix.arch }}
     runs-on: ubuntu-latest
@@ -59,8 +59,8 @@ jobs:
           cdate="$(date -u +%Y%m%d)"
           echo "date=$cdate" >> $GITHUB_ENV
           if [ -d overlay ]; then
-            sudo apt-get update -qq
-            sudo apt-get install -qq -y aapt zipalign apksigner
+            sudo apt-get update
+            sudo apt-get install -y aapt zipalign apksigner
             openssl genrsa -f4 2048 > key.pem
             openssl pkcs8 -in key.pem -topk8 -outform DER -out cert.pk8 -nocrypt
             openssl req -new -x509 -sha256 -key key.pem -out cert.pem -days 10000 -subj '/C=US/ST=California/L=Mountain View/O=Android/OU=Android/CN=Android/emailAddress=android@android.com'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,8 +59,8 @@ jobs:
           cdate="$(date -u +%Y%m%d)"
           echo "date=$cdate" >> $GITHUB_ENV
           if [ -d overlay ]; then
-            sudo apt-get update
-            sudo apt-get install -y aapt zipalign apksigner
+            sudo apt-get update -qq
+            sudo apt-get install -qq -y aapt zipalign apksigner
             openssl genrsa -f4 2048 > key.pem
             openssl pkcs8 -in key.pem -topk8 -outform DER -out cert.pk8 -nocrypt
             openssl req -new -x509 -sha256 -key key.pem -out cert.pem -days 10000 -subj '/C=US/ST=California/L=Mountain View/O=Android/OU=Android/CN=Android/emailAddress=android@android.com'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,14 +78,17 @@ jobs:
             rm key.pem
           fi
           sed -i -e 's/_%H%M%S//' build/gapps.sh
-          echo "date=$(date -u +%Y%m%d)" >> $GITHUB_ENV
+          cdate="$(date -u +%Y%m%d)"
+          echo "date=$cdate" >> $GITHUB_ENV
           ./build/gapps.sh ${{ matrix.arch }}
           sed -i -e 's@/home/runner/work/MindTheGappsBuilder/MindTheGappsBuilder/vendor_gapps/out/@@' out/MindTheGapps-${{ matrix.androidv }}-${{ matrix.arch }}-$(date -u +%Y%m%d).zip.md5sum
           mkdir -p out/${{ matrix.arch }}
-          mkdir -p out/${{ matrix.arch }}/${{ env.date }}
-          mkdir -p out/${{ matrix.arch }}/${{ env.date }}/keys
-          mv -v cert-${{ matrix.androidv }}-${{ matrix.arch }}.* out/${{ matrix.arch }}/${{ env.date }}/keys
-          mv -v out/*.* out/${{ matrix.arch }}/${{ env.date }}
+          mkdir -p out/${{ matrix.arch }}/$cdate
+          mv -v out/*.* out/${{ matrix.arch }}/$cdate
+          if [ -d overlay ]; then
+            mkdir -p out/${{ matrix.arch }}/$cdate/keys
+            mv -v cert-${{ matrix.androidv }}-${{ matrix.arch }}.* out/${{ matrix.arch }}/$cdate/keys
+          fi
 
       - name: Upload
         if: github.event.inputs.release != 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,6 +56,8 @@ jobs:
         continue-on-error: true
         run: |
           if [[ ! -d overlay && ${{ matrix.arch }} == x86_64 ]]; then exit 64; fi
+          cdate="$(date -u +%Y%m%d)"
+          echo "date=$cdate" >> $GITHUB_ENV
           if [ -d overlay ]; then
             sudo apt-get update
             sudo apt-get install -y aapt zipalign apksigner
@@ -73,13 +75,11 @@ jobs:
                 apksigner sign --key cert.pk8 --cert cert.pem "${dir/overlay\//}".apk
                 mv -v "${dir/overlay\//}".apk common/proprietary/product/overlay
             done
-            mv cert.pem cert-${{ matrix.androidv }}-${{ matrix.arch }}.pem
-            mv cert.pk8 cert-${{ matrix.androidv }}-${{ matrix.arch }}.pk8
+            mv cert.pem cert-${{ matrix.androidv }}-${{ matrix.arch }}-$cdate.pem
+            mv cert.pk8 cert-${{ matrix.androidv }}-${{ matrix.arch }}-$cdate.pk8
             rm key.pem
           fi
           sed -i -e 's/_%H%M%S//' build/gapps.sh
-          cdate="$(date -u +%Y%m%d)"
-          echo "date=$cdate" >> $GITHUB_ENV
           ./build/gapps.sh ${{ matrix.arch }}
           sed -i -e 's@/home/runner/work/MindTheGappsBuilder/MindTheGappsBuilder/vendor_gapps/out/@@' out/MindTheGapps-${{ matrix.androidv }}-${{ matrix.arch }}-$(date -u +%Y%m%d).zip.md5sum
           mkdir -p out/${{ matrix.arch }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,12 +27,6 @@ jobs:
             matrix.arch = ["arm", "arm64", "x86", "x86_64"]
             core.setOutput("matrix", JSON.stringify(matrix));
             
-      - name: Create signing keys
-        run: |
-          openssl genrsa -f4 2048 > key.pem
-          openssl pkcs8 -in key.pem -topk8 -outform DER -out cert.pk8 -nocrypt
-          openssl req -new -x509 -sha256 -key key.pem -out cert.pem -days 10000 -subj '/C=US/ST=California/L=Mountain View/O=Android/OU=Android/CN=Android/emailAddress=android@android.com'
-
   build:
     name: Build ${{ matrix.androidv }}-${{ matrix.arch }}
     runs-on: ubuntu-latest
@@ -65,6 +59,9 @@ jobs:
           if [ -d overlay ]; then
             sudo apt-get update
             sudo apt-get install -y aapt zipalign apksigner
+            openssl genrsa -f4 2048 > key.pem
+            openssl pkcs8 -in key.pem -topk8 -outform DER -out cert.pk8 -nocrypt
+            openssl req -new -x509 -sha256 -key key.pem -out cert.pem -days 10000 -subj '/C=US/ST=California/L=Mountain View/O=Android/OU=Android/CN=Android/emailAddress=android@android.com'
             mkdir common/proprietary/product/overlay
             sed -i -e '/overlay/d' build/gapps.sh
             sed -i -e '/RROs/d' build/gapps.sh
@@ -77,6 +74,8 @@ jobs:
                 apksigner sign --key cert.pk8 --cert cert.pem "${dir/overlay\//}".apk
                 mv -v "${dir/overlay\//}".apk common/proprietary/product/overlay
             done
+            mv cert.pem cert-${{ matrix.androidv }}-${{ matrix.arch }}.pem
+            mv cert.pk8 cert-${{ matrix.androidv }}-${{ matrix.arch }}.pk8
           fi
           sed -i -e 's/_%H%M%S//' build/gapps.sh
           echo "date=$(date -u +%Y%m%d)" >> $GITHUB_ENV
@@ -107,8 +106,9 @@ jobs:
         run: |
           mkdir ${{ matrix.arch }}
           mkdir ${{ matrix.arch }}/${{ env.date }}
+          mkdir ${{ matrix.arch }}/${{ env.date }}/keys
           mv *.* ${{ matrix.arch }}/${{ env.date }}
-          mv ../cert.* ${{ matrix.arch }}/${{ env.date }}
+          mv ../../cert-${{ matrix.androidv }}-${{ matrix.arch }}.* ${{ matrix.arch }}/${{ env.date }}/keys
           rsync -avP -e ssh ${{ matrix.arch }} ${{ vars.SF_USER }}@frs.sourceforge.net:/home/frs/project/wsa-mtg/
 
       - name: Release
@@ -118,6 +118,4 @@ jobs:
           tag_name: ${{ env.date }}
           draft: false
           prerelease: false
-          files: |
-            vendor_gapps/out/*
-            cert.*
+          files: vendor_gapps/out/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,7 +92,7 @@ jobs:
         with:
           name: Built_MindTheGapps-${{ matrix.androidv }}-${{ matrix.arch }}-${{ env.date }}
           path: |
-            vendor_gapps/out/${{ matrix.arch }}/${{ env.date }/*.*
+            vendor_gapps/out/${{ matrix.arch }}/${{ env.date }}/*.*
             vendor_gapps/out/${{ matrix.arch }}/${{ env.date }}/keys/
           if-no-files-found: warn
 
@@ -119,5 +119,5 @@ jobs:
           draft: false
           prerelease: false
           files: |
-            vendor_gapps/out/${{ matrix.arch }}/${{ env.date }/*.*
-            vendor_gapps/out/${{ matrix.arch }}/${{ env.date }/keys/*
+            vendor_gapps/out/${{ matrix.arch }}/${{ env.date }}/*.*
+            vendor_gapps/out/${{ matrix.arch }}/${{ env.date }}/keys/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,10 +81,11 @@ jobs:
           echo "date=$(date -u +%Y%m%d)" >> $GITHUB_ENV
           ./build/gapps.sh ${{ matrix.arch }}
           sed -i -e 's@/home/runner/work/MindTheGappsBuilder/MindTheGappsBuilder/vendor_gapps/out/@@' out/MindTheGapps-${{ matrix.androidv }}-${{ matrix.arch }}-$(date -u +%Y%m%d).zip.md5sum
+          mkdir -p out/${{ matrix.arch }}
           mkdir -p out/${{ matrix.arch }}/${{ env.date }}
           mkdir -p out/${{ matrix.arch }}/${{ env.date }}/keys
-          mv cert-${{ matrix.androidv }}-${{ matrix.arch }}.* out/${{ matrix.arch }}/${{ env.date }}/keys
-          mv out/*.* out/${{ matrix.arch }}/${{ env.date }}
+          mv -v cert-${{ matrix.androidv }}-${{ matrix.arch }}.* out/${{ matrix.arch }}/${{ env.date }}/keys
+          mv -v out/*.* out/${{ matrix.arch }}/${{ env.date }}
 
       - name: Upload
         if: github.event.inputs.release != 'true'


### PR DESCRIPTION
- [Sign overlay apks with a throwaway key](https://gitlab.com/MindTheGapps/vendor_gapps/-/commit/5ad11884)
  - [Signing of com.mtg.gmsoverlay and com.mtg.gmssettingsprovideroverlay uses a publicly known/shared private key](https://gitlab.com/MindTheGapps/vendor_gapps/-/issues/10)
    - <https://gitlab.com/LineageOS/issues/android/-/issues/5230>
- [Use apksigner for signing overlay apks](https://gitlab.com/MindTheGapps/vendor_gapps/-/commit/461da2f4)

---

With this change, we will also change the file used for that signature to be uploaded.  
Actually, it is not necessary, but done just in case.