### PR TITLE
Fix "Setup SSH" error

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,7 +103,6 @@ jobs:
           ssh-keyscan frs.sourceforge.net >> ~/.ssh/known_hosts
           echo "${{ secrets.SSH_KEY }}" > ~/.ssh/id_ed25519
           chmod 0600 ~/.ssh/id_ed25519
-          ssh -T ${{ vars.SF_USER }}@frs.sourceforge.net
 
       - name: Upload to SourceForge
         continue-on-error: true


### PR DESCRIPTION
```
Welcome!

This is a restricted Shell Account.
You can only copy files to/from here.

Error: Process completed with exit code 1.
```

---

The connection is successful, but the exit code is non `0` because of "Terminate".